### PR TITLE
Add support for JavaScript target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for the JavaScript target.
+
 ## [2.0.0] - 2025-05-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Package Version](https://img.shields.io/hexpm/v/bigben)](https://hex.pm/packages/bigben)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/bigben/)
 ![Erlang-compatible](https://img.shields.io/badge/target-erlang-b83998)
+![JavaScript-compatible](https://img.shields.io/badge/target-javascript-f1e05a)
 
 🕰️ A clock abstraction, with time travel.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,10 +5,9 @@ licenses = ["MIT"]
 repository = { type = "github", user = "maxdeviant", repo = "bigben" }
 
 [dependencies]
-gleam_erlang = ">= 1.2.0 and < 2.0.0"
-gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.62.0 and < 1.0.0"
 gleam_time = ">= 1.4.0 and < 2.0.0"
+interior = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.6.1 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,11 +7,11 @@ packages = [
   { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
   { name = "gleam_time", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "DCDDC040CE97DA3D2A925CDBBA08D8A78681139745754A83998641C8A3F6587E" },
   { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
+  { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
-gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.62.0 and < 1.0.0" }
 gleam_time = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.6.1 and < 2.0.0" }
+interior = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/bigben/fake_clock.gleam
+++ b/src/bigben/fake_clock.gleam
@@ -1,13 +1,12 @@
 //// A fake clock for manipulating the flow of time.
 
-import gleam/erlang/process.{type Subject}
-import gleam/otp/actor
 import gleam/time/duration.{type Duration}
 import gleam/time/timestamp.{type Timestamp}
+import interior/cell.{type Cell}
 
 /// A fake clock.
 pub opaque type FakeClock {
-  FakeClock(subject: Subject(Message))
+  FakeClock(now: Cell(Timestamp))
 }
 
 /// Returns a new `FakeClock`.
@@ -19,39 +18,20 @@ pub fn new() -> FakeClock {
 
 /// Returns a new `FakeClock` at the given time.
 pub fn new_at(now: Timestamp) -> FakeClock {
-  let assert Ok(actor) =
-    actor.new(now) |> actor.on_message(handle_message) |> actor.start
-  FakeClock(actor.data)
+  FakeClock(cell.new(now))
 }
 
 /// Returns the current time on the given `FakeClock`.
 pub fn now(clock: FakeClock) -> Timestamp {
-  process.call(clock.subject, 10, Get)
+  cell.get(clock.now)
 }
 
 /// Sets the current time on the given `FakeClock` to the specified value.
 pub fn set_now(clock: FakeClock, now: Timestamp) -> Nil {
-  process.send(clock.subject, Set(now))
+  cell.set(clock.now, now)
 }
 
 /// Advances the given `FakeClock` by the specified duration.
 pub fn advance(clock: FakeClock, duration: Duration) -> Nil {
-  process.send(clock.subject, Advance(duration))
-}
-
-type Message {
-  Get(reply_with: Subject(Timestamp))
-  Set(Timestamp)
-  Advance(Duration)
-}
-
-fn handle_message(state: Timestamp, message: Message) {
-  case message {
-    Get(client) -> {
-      process.send(client, state)
-      actor.continue(state)
-    }
-    Set(now) -> actor.continue(now)
-    Advance(duration) -> actor.continue(timestamp.add(state, duration))
-  }
+  cell.update(clock.now, timestamp.add(_, duration))
 }


### PR DESCRIPTION
This PR adds support for the JavaScript target.

We're now using `interior`—which supports both the Erlang and JavaScript targets—to implement the `FakeClock`, which now allows us to run on the JavaScript target.